### PR TITLE
Let WiX grap Newtonsoft.Json from package folder

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -235,7 +235,7 @@
                 <File Source="..\Plugins\ReleaseNotesGenerator\bin\Release\ReleaseNotesGenerator.dll" />
             </Component>
             <Component Id="Newtonsoft.Json.dll" Guid="*">
-                <File Source="..\GitExtensions\bin\Release\Newtonsoft.Json.dll" />
+                <File Source="..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll" />
             </Component>
             <!--Remove unused dll, installed in versions <= 2.31-->
             <Component Id="Github.dll" Guid="0DA13691-140A-4490-8B4C-8AF537DAEB67">


### PR DESCRIPTION
Building installer from a clean working copy failed to find the
Newtonsoft.Json assembly in the Release folder.